### PR TITLE
    maint: add build tests     

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: ci
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+jobs:
+  test-stack:
+    strategy:
+      matrix:
+        stack: [heroku-22, heroku-24]
+    runs-on: sfdc-hk-ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: run stack test
+      run: bash test/test-stack.sh ${{ matrix.stack }}
+      env:
+        REPO_OWNER: heroku
+        REPO_PROJECT: heroku-integration-service-mesh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE=heroku/heroku:24-build
+FROM $BASE_IMAGE
+
+ARG STACK
+USER root
+
+
+ARG REPO_OWNER=heroku
+ARG REPO_PROJECT=heroku-applink-service-mesh
+
+RUN mkdir -p /app /cache /env
+RUN echo "${REPO_OWNER}" > /env/HEROKU_APPLINK_SERVICE_MESH_REPO_OWNER
+RUN echo "${REPO_PROJECT}" > /env/HEROKU_APPLINK_SERVICE_MESH_REPO_PROJECT
+
+COPY . /buildpack
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when it's run by Heroku CI.
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env
+WORKDIR /app

--- a/test/test-stack.sh
+++ b/test/test-stack.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[ $# -eq 1 ] || { echo "Usage: $0 STACK"; exit 1; }
+
+STACK="${1}"
+BASE_IMAGE="heroku/${STACK/-/:}-build"
+OUTPUT_IMAGE="applink-buildpack-test-${STACK}"
+
+echo "Building applinkbuildpack on stack ${STACK}..."
+
+docker build \
+    --build-arg STACK="$STACK" \
+    --build-arg BASE_IMAGE="$BASE_IMAGE" \
+    --build-arg REPO_OWNER="${REPO_OWNER:-heroku}" \
+    --build-arg REPO_PROJECT="${REPO_PROJECT:-heroku-applink-service-mesh}" \
+    -t "$OUTPUT_IMAGE" \
+    .


### PR DESCRIPTION

  This commit adds a very brief smoke test on the buildpack to install the
  buildpack, including the binary.
  
  Right now it points to the old integration repo and uses an internal
  runner for now (due to private repo) but should be updated when public.
    
  Ref: [W-18356113: [Testing] Test Plan & Coverage](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002DNjrkYAD/view)