### PR TITLE
Link from predictable location

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -99,4 +99,4 @@ echo 'export PATH="$PATH:'$HOME/$VENDOR_DIR'"' >> $PROFILE_PATH
 rm -f "$DOWNLOAD_INSTALL_DIR/public-key.asc" "${DOWNLOAD_INSTALL_DIR}/${BINARY_NAME}.asc"
 
 echo "Done!" | indent
-echo "-----> Ensure that $BINARY_NAME is configured in your Procfile's web process to start your app, eg $BINARY_NAME <app startup command>"
+echo "-----> Ensure that heroku-applink-service-mesh is configured in your Procfile's web process to start your app, eg heroku-applink-service-mesh <app startup command>"

--- a/bin/compile
+++ b/bin/compile
@@ -90,6 +90,7 @@ fi
 
 echo "Installing $BINARY_NAME..." | indent
 chmod +x "$DOWNLOAD_INSTALL_DIR/$BINARY_NAME"
+ln -s "$BINARY_NAME" "$DOWNLOAD_INSTALL_DIR/heroku-applink-service-mesh"
 PROFILE_PATH="$BUILD_DIR/.profile.d/$BINARY_NAME.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 echo 'export PATH="$PATH:'$HOME/$VENDOR_DIR'"' >> $PROFILE_PATH


### PR DESCRIPTION
As raised in https://github.com/heroku/heroku-buildpack-heroku-applink-service-mesh/pull/7#discussion_r2102399357, it's inconvenient if you need to change your Procfile when we release a new version.

This change creates a symbolic link from "heroku-applink-service-mesh" to the current version to avoid that issue.