### PR TITLE
Add build script and buildpack.toml files for the CNB compatibility

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -30,18 +30,16 @@ if [ -f "${APP_DIR}/Procfile" ]; then
         echo " !     No web process found in Procfile"
         exit 1
     fi
-elif [[ "$WEB_COMMAND" ==~ "$BINARY_NAME" ]]; then
-    echo " !     Web process already contains the heroku-applink-service-mesh binary name"
-else
-    echo " !     Procfile not found at ${APP_DIR}/Procfile"
-    exit 1
-fi
 
-VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
-BINARY_NAME="heroku-applink-service-mesh"
+    # shellcheck disable=SC1009 disable=SC1073 disable=SC1035 disable=SC1072
+    if [[ "$WEB_COMMAND" ==~ "$BINARY_NAME" ]]; then
+        echo " !     Web process already contains the heroku-applink-service-mesh binary name"
+    else
+        VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
+        BINARY_NAME="heroku-applink-service-mesh"
 
-# Create layer metadata
-cat > "${LAYERS_DIR}/heroku-applink-service-mesh.toml" << EOL
+        # Create layer metadata
+        cat > "${LAYERS_DIR}/heroku-applink-service-mesh.toml" << EOL
 [types]
 launch = true
 build = false
@@ -52,14 +50,20 @@ version = "${VERSION}"
 arch = "${ARCH}"
 EOL
 
-# Create launch.toml to set the start command
-cat > "${LAYERS_DIR}/launch.toml" << EOL
+        # Create launch.toml to set the start command
+        cat > "${LAYERS_DIR}/launch.toml" << EOL
 [[processes]]
 type = "web"
 command = ["${APP_DIR}/vendor/heroku-applink/bin/${BINARY_NAME}", "${WEB_COMMAND}"]
 EOL
 
-echo "-----> Command to be executed: vendor/heroku-applink/bin/${BINARY_NAME} ${WEB_COMMAND}"
-echo "-----> The service mesh will automatically wrap your web process at runtime"
+        echo "-----> Command to be executed: vendor/heroku-applink/bin/${BINARY_NAME} ${WEB_COMMAND}"
+        echo "-----> The service mesh will automatically wrap your web process at runtime"
+    fi
+else
+    echo " !     Procfile not found at ${APP_DIR}/Procfile"
+    exit 1
+fi
+
 echo "-----> Done!"
 

--- a/bin/build
+++ b/bin/build
@@ -65,7 +65,7 @@ EOL
 cat > "${LAYERS_DIR}/launch.toml" << EOL
 [[processes]]
 type = "web"
-command = ["vendor/heroku-applink/bin/${BINARY_NAME}", "${WEB_COMMAND}"]
+command = ["${APP_DIR}/vendor/heroku-applink/bin/${BINARY_NAME}", "${WEB_COMMAND}"]
 EOL
 
 echo "-----> Command to be executed: vendor/heroku-applink/bin/${BINARY_NAME} ${WEB_COMMAND}"

--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,74 @@
+#!/bin/sh
+
+set -e
+
+# CNB buildpack specific variables
+LAYERS_DIR="$1"
+PLATFORM_DIR="$2"
+APP_DIR="/workspace"
+
+echo "-----> Installing Heroku AppLink Service Mesh..."
+
+# Create layers directory structure
+mkdir -p "${LAYERS_DIR}/heroku-applink-service-mesh"
+
+# Setup installation paths
+DOWNLOAD_INSTALL_DIR="${APP_DIR}/vendor/heroku-applink/bin"
+mkdir -p $DOWNLOAD_INSTALL_DIR
+
+# Create empty env directory for legacy buildpack compatibility
+mkdir -p "${PLATFORM_DIR}/env"
+
+# Run the compile script with the appropriate directories
+"$(dirname "$0")/compile" "$APP_DIR" "$LAYERS_DIR" "${PLATFORM_DIR}/env"
+
+# Read web process from Procfile
+echo "-----> Reading web process from Procfile..."
+if [ -f "${APP_DIR}/Procfile" ]; then
+    WEB_COMMAND=$(grep "^web:" "${APP_DIR}/Procfile" | sed 's/^web: //')
+    if [ -z "$WEB_COMMAND" ]; then
+        echo " !     No web process found in Procfile"
+        exit 1
+    fi
+else
+    echo " !     Procfile not found at ${APP_DIR}/Procfile"
+    exit 1
+fi
+
+# Get binary name from compile script
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ]; then
+    ARCH="amd64"
+elif [ "$ARCH" = "arm64" ]; then
+    ARCH="arm64"
+else
+    echo " !     Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
+BINARY_NAME="heroku-applink-service-mesh-${VERSION}-${ARCH}"
+
+# Create layer metadata
+cat > "${LAYERS_DIR}/heroku-applink-service-mesh.toml" << EOL
+[types]
+launch = true
+build = false
+cache = false
+
+[metadata]
+version = "${VERSION}"
+arch = "${ARCH}"
+EOL
+
+# Create launch.toml to set the start command
+cat > "${LAYERS_DIR}/launch.toml" << EOL
+[[processes]]
+type = "web"
+command = ["vendor/heroku-applink/bin/${BINARY_NAME}", "${WEB_COMMAND}"]
+EOL
+
+echo "-----> Command to be executed: vendor/heroku-applink/bin/${BINARY_NAME} ${WEB_COMMAND}"
+echo "-----> The service mesh will automatically wrap your web process at runtime"
+echo "-----> Done!"
+

--- a/bin/build
+++ b/bin/build
@@ -30,24 +30,15 @@ if [ -f "${APP_DIR}/Procfile" ]; then
         echo " !     No web process found in Procfile"
         exit 1
     fi
+elif [[ "$WEB_COMMAND" ==~ "$BINARY_NAME" ]]; then
+    echo " !     Web process already contains the heroku-applink-service-mesh binary name"
 else
     echo " !     Procfile not found at ${APP_DIR}/Procfile"
     exit 1
 fi
 
-# Get binary name from compile script
-ARCH=$(uname -m)
-if [ "$ARCH" = "x86_64" ]; then
-    ARCH="amd64"
-elif [ "$ARCH" = "arm64" ]; then
-    ARCH="arm64"
-else
-    echo " !     Unsupported architecture: $ARCH"
-    exit 1
-fi
-
 VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
-BINARY_NAME="heroku-applink-service-mesh-${VERSION}-${ARCH}"
+BINARY_NAME="heroku-applink-service-mesh"
 
 # Create layer metadata
 cat > "${LAYERS_DIR}/heroku-applink-service-mesh.toml" << EOL

--- a/bin/compile
+++ b/bin/compile
@@ -35,9 +35,9 @@ export_env_dir "$ENV_DIR"
 # Detect architecture
 ARCH=$(uname -m)
 if [ "$ARCH" = "x86_64" ]; then
-    ARCH="amd64"
-elif [ "$ARCH" = "arm64" ]; then
-    ARCH="arm64"
+    export ARCH="amd64"
+elif [ "$ARCH" = "aarch64" ]; then
+    export ARCH="arm64"
 else
     echo " !     Unsupported architecture: $ARCH"
     exit 1

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,0 +1,9 @@
+api = "0.10"
+
+[buildpack]
+id = "heroku.com/heroku-applink-buildpack"
+version = "1.0"
+
+# Targets the buildpack will work with
+[[targets]]
+os = "linux"


### PR DESCRIPTION
[W-18042567](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002B5x5ZYAR/view)

CNB requires a slightly different file structure but since the compile script is now downloading and verifying signature it can be re-used and make this buildpack compatible with CNB

CNB also allow us to modify the launcher commands and insert the mesh binary in the process without changing the Procfile, this is the buildoutput:

```
===> BUILDING
[builder] -----> Installing Heroku AppLink Service Mesh...
[builder] -----> Installing Heroku AppLink Service Mesh for amd64...
[builder]        Downloading heroku-applink-service-mesh-latest-amd64...
[builder]        Importing public key...
[builder] gpg: directory '/home/heroku/.gnupg' created
[builder] gpg: keybox '/home/heroku/.gnupg/pubring.kbx' created
[builder] gpg: /home/heroku/.gnupg/trustdb.gpg: trustdb created
[builder] gpg: key D3EE2097B345FBFE: public key "Heroku EDIT <heroku-edit@salesforce.com>" imported
[builder] gpg: Total number processed: 1
[builder] gpg:               imported: 1
[builder]        Verifying binary signature...
[builder] gpg: Signature made Thu Jun  5 12:15:59 2025 UTC
[builder] gpg:                using EDDSA key 7B10D7CF717F04162232AAEBD3EE2097B345FBFE
[builder] gpg: Good signature from "Heroku EDIT <heroku-edit@salesforce.com>" [unknown]
[builder] gpg: WARNING: This key is not certified with a trusted signature!
[builder] gpg:          There is no indication that the signature belongs to the owner.
[builder] Primary key fingerprint: 7B10 D7CF 717F 0416 2232  AAEB D3EE 2097 B345 FBFE
[builder]        Installing heroku-applink-service-mesh-latest-amd64...
[builder]        Done!
[builder] -----> Ensure that heroku-applink-service-mesh-latest-amd64 is configured in your Procfile's web process to start your app, eg heroku-applink-service-mesh-latest-amd64 <app startup command>
[builder] -----> Reading web process from Procfile...
[builder] -----> Command to be executed: vendor/heroku-applink/bin/heroku-applink-service-mesh-latest-amd64 go-getting-started
[builder] -----> The service mesh will automatically wrap your web process at runtime
[builder] -----> Done!
```