### PR TITLE
Cloud Native Buildpack Fixes

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -22,26 +22,55 @@ if [ -f "${PLATFORM_DIR}/env/HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION" ]; the
     export HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION=$(cat "${PLATFORM_DIR}/env/HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION")
 fi
 
-# Source the shared utility
 source "$(dirname "$0")/../lib/applink_installer.sh"
 
-# Install binary to layer bin directory (automatically added to PATH)
-mkdir -p "${LAYER_DIR}/bin"
-if ! install_applink_binary "${LAYER_DIR}/bin"; then
-    echo " !     Failed to install Heroku AppLink Service Mesh binary"
-    exit 1
+# Determine current arch for caching
+CURRENT_ARCH=$(detect_arch)
+
+# Get current ETag from S3 to check for changes
+S3_BUCKET="${HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET:-heroku-applink-service-mesh-binaries}"
+VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
+BINARY_NAME="heroku-applink-service-mesh-${VERSION}-${CURRENT_ARCH}"
+S3_URL="https://${S3_BUCKET}.s3.amazonaws.com/${BINARY_NAME}"
+
+echo "-----> Checking for cached Heroku AppLink Service Mesh..."
+CURRENT_ETAG=$(curl -sI "$S3_URL" | grep -i etag | cut -d'"' -f2 | tr -d '\r')
+
+# Check if we can reuse the existing layer
+LAYER_NEEDS_REBUILD=true
+if [ -f "${LAYER_DIR}.toml" ]; then
+    # Read cached metadata (handle indented TOML)
+    CACHED_ETAG=$(grep "etag = " "${LAYER_DIR}.toml" | cut -d'"' -f2 2>/dev/null || echo "")
+    CACHED_ARCH=$(grep "arch = " "${LAYER_DIR}.toml" | cut -d'"' -f2 2>/dev/null || echo "")
+
+    # Check if binary exists and metadata matches
+    if [ -f "${LAYER_DIR}/bin/heroku-applink-service-mesh" ] && \
+       [ "$CACHED_ETAG" = "$CURRENT_ETAG" ] && \
+       [ "$CACHED_ARCH" = "$CURRENT_ARCH" ]; then
+        echo "-----> Reusing cached Heroku AppLink Service Mesh"
+        LAYER_NEEDS_REBUILD=false
+    fi
 fi
 
-# Create layer metadata
+if [ "$LAYER_NEEDS_REBUILD" = "true" ]; then
+    # Install binary to layer bin directory (automatically added to PATH)
+    mkdir -p "${LAYER_DIR}/bin"
+    if ! install_applink_binary "${LAYER_DIR}/bin" "$CURRENT_ARCH" "$VERSION" "$S3_BUCKET"; then
+        echo " !     Failed to install Heroku AppLink Service Mesh binary"
+        exit 1
+    fi
+fi
+
+# Create/update layer metadata
 cat > "${LAYER_DIR}.toml" << EOL
 [types]
 launch = true
 build = false
-cache = false
+cache = true
 
 [metadata]
-version = "${APPLINK_VERSION}"
-arch = "${APPLINK_ARCH}"
+etag = "${CURRENT_ETAG}"
+arch = "${CURRENT_ARCH}"
 EOL
 
 

--- a/bin/build
+++ b/bin/build
@@ -10,18 +10,31 @@ APP_DIR="/workspace"
 echo "-----> Installing Heroku AppLink Service Mesh..."
 
 # Create layers directory structure
-LAYER_DIR="${LAYERS_DIR}/heroku-applink-service-mesh"
-mkdir -p $LAYER_DIR
+LAYER_DIR="${LAYERS_DIR}/service-mesh"
+mkdir -p "$LAYER_DIR"
 
-# Setup installation paths
-DOWNLOAD_INSTALL_DIR="${APP_DIR}/vendor/heroku-applink/bin"
-mkdir -p $DOWNLOAD_INSTALL_DIR
+# Source the shared utility
+source "$(dirname "$0")/../lib/applink_installer.sh"
 
-# Create empty env directory for legacy buildpack compatibility
-mkdir -p "${PLATFORM_DIR}/env"
+# Install binary to layer bin directory (automatically added to PATH)
+mkdir -p "${LAYER_DIR}/bin"
+if ! install_applink_binary "${LAYER_DIR}/bin"; then
+    echo " !     Failed to install Heroku AppLink Service Mesh binary"
+    exit 1
+fi
 
-# Run the compile script with the appropriate directories
-"$(dirname "$0")/compile" "$APP_DIR" "$LAYER_DIR" "${PLATFORM_DIR}/env"
+# Create layer metadata
+cat > "${LAYER_DIR}.toml" << EOL
+[types]
+launch = true
+build = false
+cache = false
+
+[metadata]
+version = "${APPLINK_VERSION}"
+arch = "${APPLINK_ARCH}"
+EOL
+
 
 # Read web process from Procfile
 echo "-----> Reading web process from Procfile..."
@@ -32,35 +45,20 @@ if [ -f "${APP_DIR}/Procfile" ]; then
         exit 1
     fi
 
-    # Define binary name first
     BINARY_NAME="heroku-applink-service-mesh"
 
     # Check if web command already contains the binary name
     if [[ "$WEB_COMMAND" =~ "$BINARY_NAME" ]]; then
         echo " !     Web process already contains the heroku-applink-service-mesh binary name"
     else
-        VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
-
-        # Create layer metadata
-        cat > "${LAYERS_DIR}/heroku-applink-service-mesh.toml" << EOL
-[types]
-launch = true
-build = false
-cache = false
-
-[metadata]
-version = "${VERSION}"
-arch = "${ARCH}"
-EOL
-
         # Create launch.toml to set the start command
         cat > "${LAYERS_DIR}/launch.toml" << EOL
 [[processes]]
 type = "web"
-command = ["${APP_DIR}/vendor/heroku-applink/bin/${BINARY_NAME}", "${WEB_COMMAND}"]
+command = ["${APPLINK_BINARY_NAME}", "${WEB_COMMAND}"]
 EOL
 
-        echo "-----> Command to be executed: vendor/heroku-applink/bin/${BINARY_NAME} ${WEB_COMMAND}"
+        echo "-----> Command to be executed: ${APPLINK_BINARY_NAME} ${WEB_COMMAND}"
         echo "-----> The service mesh will automatically wrap your web process at runtime"
     fi
 else

--- a/bin/build
+++ b/bin/build
@@ -10,7 +10,8 @@ APP_DIR="/workspace"
 echo "-----> Installing Heroku AppLink Service Mesh..."
 
 # Create layers directory structure
-mkdir -p "${LAYERS_DIR}/heroku-applink-service-mesh"
+LAYER_DIR="${LAYERS_DIR}/heroku-applink-service-mesh"
+mkdir -p $LAYER_DIR
 
 # Setup installation paths
 DOWNLOAD_INSTALL_DIR="${APP_DIR}/vendor/heroku-applink/bin"
@@ -20,7 +21,7 @@ mkdir -p $DOWNLOAD_INSTALL_DIR
 mkdir -p "${PLATFORM_DIR}/env"
 
 # Run the compile script with the appropriate directories
-"$(dirname "$0")/compile" "$APP_DIR" "$LAYERS_DIR" "${PLATFORM_DIR}/env"
+"$(dirname "$0")/compile" "$APP_DIR" "$LAYER_DIR" "${PLATFORM_DIR}/env"
 
 # Read web process from Procfile
 echo "-----> Reading web process from Procfile..."

--- a/bin/build
+++ b/bin/build
@@ -13,6 +13,15 @@ echo "-----> Installing Heroku AppLink Service Mesh..."
 LAYER_DIR="${LAYERS_DIR}/service-mesh"
 mkdir -p "$LAYER_DIR"
 
+# Read allowed environment variables from platform directory
+if [ -f "${PLATFORM_DIR}/env/HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET" ]; then
+    export HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET=$(cat "${PLATFORM_DIR}/env/HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET")
+fi
+
+if [ -f "${PLATFORM_DIR}/env/HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION" ]; then
+    export HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION=$(cat "${PLATFORM_DIR}/env/HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION")
+fi
+
 # Source the shared utility
 source "$(dirname "$0")/../lib/applink_installer.sh"
 

--- a/bin/build
+++ b/bin/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -31,12 +31,14 @@ if [ -f "${APP_DIR}/Procfile" ]; then
         exit 1
     fi
 
-    # shellcheck disable=SC1009 disable=SC1073 disable=SC1035 disable=SC1072
-    if [[ "$WEB_COMMAND" ==~ "$BINARY_NAME" ]]; then
+    # Define binary name first
+    BINARY_NAME="heroku-applink-service-mesh"
+
+    # Check if web command already contains the binary name
+    if [[ "$WEB_COMMAND" =~ "$BINARY_NAME" ]]; then
         echo " !     Web process already contains the heroku-applink-service-mesh binary name"
     else
         VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
-        BINARY_NAME="heroku-applink-service-mesh"
 
         # Create layer metadata
         cat > "${LAYERS_DIR}/heroku-applink-service-mesh.toml" << EOL

--- a/bin/compile
+++ b/bin/compile
@@ -2,9 +2,8 @@
 
 set -euo pipefail
 
-indent() {
-    sed -u 's/^/       /'
-}
+# Source the shared utility
+source "$(dirname "$0")/../lib/applink_installer.sh"
 
 export_env_dir() {
   local env_dir=$1
@@ -32,77 +31,19 @@ ENV_DIR="$3"
 # Export env files as env vars
 export_env_dir "$ENV_DIR"
 
-# Detect architecture
-ARCH=$(uname -m)
-if [ "$ARCH" = "x86_64" ]; then
-    export ARCH="amd64"
-elif [ "$ARCH" = "aarch64" ]; then
-    export ARCH="arm64"
-else
-    echo " !     Unsupported architecture: $ARCH"
-    exit 1
-fi
-
-# Setup S3 URL
-S3_BUCKET="${HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET:-heroku-applink-service-mesh-binaries}"
-VERSION="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
-BINARY_NAME="heroku-applink-service-mesh-${VERSION}-${ARCH}"
-S3_URL="https://${S3_BUCKET}.s3.amazonaws.com/${BINARY_NAME}"
-ASC_URL="${S3_URL}.asc"
-PUBKEY_URL="https://heroku-applink-service-mesh-binaries.s3.amazonaws.com/public-key.asc"
-WELL_KNOWN_BINARY_NAME="heroku-applink-service-mesh"
-
-# Setup installation paths
+# Setup installation paths for classic buildpack
 VENDOR_DIR="vendor/heroku-applink/bin"
 DOWNLOAD_INSTALL_DIR="$BUILD_DIR/$VENDOR_DIR"
-mkdir -p "$DOWNLOAD_INSTALL_DIR"
 
-# Require gpg
-if ! command -v gpg > /dev/null; then
-    echo " !     gpg is not installed!"
-    echo " !     Ensure the app is on the latest Heroku stack"
+if ! install_applink_binary "$DOWNLOAD_INSTALL_DIR"; then
+    echo " !     Failed to install Heroku AppLink Service Mesh binary"
     exit 1
 fi
 
-# Download
-echo "-----> Installing Heroku AppLink Service Mesh for $ARCH..."
-echo "Downloading $BINARY_NAME..." | indent
-CURRENT_DIR=$(pwd)
-cd "$DOWNLOAD_INSTALL_DIR"
-
-# Download binary, signature and public key
-curl -JLs "$S3_URL" -o "$BINARY_NAME"
-curl -JLs "$ASC_URL" -o "${BINARY_NAME}.asc"
-curl -JLs "$PUBKEY_URL" -o "public-key.asc"
-
-# Import public key
-echo "Importing public key..." | indent
-gpg --import public-key.asc
-
-# Verify signature
-echo "Verifying binary signature..." | indent
-if ! gpg --verify "${BINARY_NAME}.asc" "$BINARY_NAME"; then
-    echo " !     Binary signature verification failed!"
-    exit 1
-fi
-
-cd "$CURRENT_DIR"
-
-if [ ! -f "$DOWNLOAD_INSTALL_DIR/$BINARY_NAME" ]; then
-    echo " !     Heroku AppLink Service Mesh binary not found at $DOWNLOAD_INSTALL_DIR/$BINARY_NAME!"
-    exit 1
-fi
-
-echo "Installing $BINARY_NAME..." | indent
-chmod +x "$DOWNLOAD_INSTALL_DIR/$BINARY_NAME"
-# force the link to be the binary name to use /app/vendor/heroku-applink/bin/heroku-applink-service-mesh-<version>-<arch> as the source
-ln -sf "/app/$VENDOR_DIR/$BINARY_NAME" "$DOWNLOAD_INSTALL_DIR/$WELL_KNOWN_BINARY_NAME"
-PROFILE_PATH="$BUILD_DIR/.profile.d/$BINARY_NAME.sh"
+# Setup .profile.d for PATH
+PROFILE_PATH="$BUILD_DIR/.profile.d/heroku-applink-service-mesh.sh"
 mkdir -p "$(dirname "$PROFILE_PATH")"
-echo "export PATH=\"\$PATH:$HOME/$VENDOR_DIR\"" >> "$PROFILE_PATH"
+echo "export PATH=\"\$PATH:\$HOME/$VENDOR_DIR\"" >> "$PROFILE_PATH"
 
-# Cleanup
-rm -f "$DOWNLOAD_INSTALL_DIR/public-key.asc" "${DOWNLOAD_INSTALL_DIR}/${BINARY_NAME}.asc"
-
-echo "Done!" | indent
-echo "-----> Ensure that $WELL_KNOWN_BINARY_NAME is configured in your Procfile's web process to start your app, eg $WELL_KNOWN_BINARY_NAME <app startup command>"
+# Create symlink for runtime (/app path)
+ln -sf "/app/$VENDOR_DIR/$(basename "$APPLINK_BINARY_PATH")" "$DOWNLOAD_INSTALL_DIR/$APPLINK_BINARY_NAME"

--- a/bin/compile
+++ b/bin/compile
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 
-# Source the shared utility
 source "$(dirname "$0")/../lib/applink_installer.sh"
 
 export_env_dir() {

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,8 +1,9 @@
 api = "0.10"
 
 [buildpack]
-id = "heroku.com/heroku-applink-buildpack"
+id = "heroku/heroku-applink"
 version = "1.0"
+clear-env = true
 
 # Targets the buildpack will work with
 [[targets]]

--- a/lib/applink_installer.sh
+++ b/lib/applink_installer.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Utility for downloading, verifying, and installing Heroku AppLink Service Mesh binary
+install_applink_binary() {
+    local install_dir="$1"
+
+    # Detect architecture
+    local arch
+    arch=$(uname -m)
+    if [ "$arch" = "x86_64" ]; then
+        arch="amd64"
+    elif [ "$arch" = "aarch64" ]; then
+        arch="arm64"
+    else
+        echo " !     Unsupported architecture: $arch" >&2
+        return 1
+    fi
+
+    # Setup S3 URL
+    local s3_bucket="${HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET:-heroku-applink-service-mesh-binaries}"
+    local version="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
+    local binary_name="heroku-applink-service-mesh-${version}-${arch}"
+    local s3_url="https://${s3_bucket}.s3.amazonaws.com/${binary_name}"
+    local asc_url="${s3_url}.asc"
+    local pubkey_url="https://heroku-applink-service-mesh-binaries.s3.amazonaws.com/public-key.asc"
+    local well_known_binary_name="heroku-applink-service-mesh"
+
+    # Create installation directory
+    mkdir -p "$install_dir"
+
+    # Require gpg
+    if ! command -v gpg > /dev/null; then
+        echo " !     gpg is not installed!" >&2
+        echo " !     Ensure the app is on the latest Heroku stack" >&2
+        return 1
+    fi
+
+    # Download and verify
+    echo "-----> Installing Heroku AppLink Service Mesh for $arch..."
+    echo "       Downloading $binary_name..."
+    local current_dir
+    current_dir=$(pwd)
+    cd "$install_dir"
+
+    # Download binary, signature and public key
+    curl -JLs "$s3_url" -o "$binary_name"
+    curl -JLs "$asc_url" -o "${binary_name}.asc"
+    curl -JLs "$pubkey_url" -o "public-key.asc"
+
+    # Import public key
+    echo "       Importing public key..."
+    gpg --import public-key.asc
+
+    # Verify signature
+    echo "       Verifying binary signature..."
+    if ! gpg --verify "${binary_name}.asc" "$binary_name"; then
+        echo " !     Binary signature verification failed!" >&2
+        cd "$current_dir"
+        return 1
+    fi
+
+    cd "$current_dir"
+
+    # Install binary
+    if [ ! -f "$install_dir/$binary_name" ]; then
+        echo " !     Heroku AppLink Service Mesh binary not found at $install_dir/$binary_name!" >&2
+        return 1
+    fi
+
+    echo "       Installing $binary_name..."
+    chmod +x "$install_dir/$binary_name"
+
+    # Create symlink for well-known name
+    ln -sf "$binary_name" "$install_dir/$well_known_binary_name"
+
+    # Cleanup
+    rm -f "$install_dir/public-key.asc" "${install_dir}/${binary_name}.asc"
+
+    echo "       Done!"
+
+    # Export results for caller
+    export APPLINK_BINARY_PATH="$install_dir/$well_known_binary_name"
+    export APPLINK_BINARY_NAME="$well_known_binary_name"
+    export APPLINK_ARCH="$arch"
+    export APPLINK_VERSION="$version"
+
+    return 0
+}

--- a/lib/applink_installer.sh
+++ b/lib/applink_installer.sh
@@ -2,25 +2,28 @@
 
 set -euo pipefail
 
-# Utility for downloading, verifying, and installing Heroku AppLink Service Mesh binary
-install_applink_binary() {
-    local install_dir="$1"
-
-    # Detect architecture
+# Detect and normalize architecture
+detect_arch() {
     local arch
     arch=$(uname -m)
     if [ "$arch" = "x86_64" ]; then
-        arch="amd64"
+        echo "amd64"
     elif [ "$arch" = "aarch64" ]; then
-        arch="arm64"
+        echo "arm64"
     else
         echo " !     Unsupported architecture: $arch" >&2
         return 1
     fi
+}
+
+# Utility for downloading, verifying, and installing Heroku AppLink Service Mesh binary
+install_applink_binary() {
+    local install_dir="$1"
+    local arch="${2:-$(detect_arch)}"
+    local version="${3:-${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}}"
+    local s3_bucket="${4:-${HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET:-heroku-applink-service-mesh-binaries}}"
 
     # Setup S3 URL
-    local s3_bucket="${HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET:-heroku-applink-service-mesh-binaries}"
-    local version="${HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION:-latest}"
     local binary_name="heroku-applink-service-mesh-${version}-${arch}"
     local s3_url="https://${s3_bucket}.s3.amazonaws.com/${binary_name}"
     local asc_url="${s3_url}.asc"


### PR DESCRIPTION
This revisits the Cloud Native Buildpack support.
* align with using `bash` over `/bin/sh` for `bin/build`
* extract common functionality between the classic and cnb in a new `lib/applink_installer.sh`
* install the service mesh binary into a layer dir for the CNB and put it on the `$PATH` so the same `Procfile` works between classic and CNB
* use `clear-env` option in CNB so we don't auto import all env vars and instead only use `HEROKU_APPLINK_SERVICE_MESH_S3_BUCKET` and `HEROKU_APPLINK_SERVICE_MESH_RELEASE_VERSION`
* add layer re-use caching based off arch and S3 ETag. versioning is inadequate since users can set `latest`.